### PR TITLE
change first line 'var moduleName;' to get moduleName from global window

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,17 @@ var services;
 ``` javascript
 require("ts-global-module-loader?./file.js");
 ```
-will adds below code the the file's source:
+will modify the code file's source to:
 ``` javascript
+var services = window["services"];
+(function (services) {
+    var Foo = (function () {
+        function Foo() {
+        }
+        return Foo;
+    }());
+    services.Foo = Foo;
+})(services || (services = {}));
 window["services"] = (services);
 ```
 Inspired by https://github.com/webpack/exports-loader;

--- a/index.js
+++ b/index.js
@@ -23,6 +23,8 @@ module.exports = function (content, sourceMap) {
   var exports = [];
   var modules = getTsModules(content);
 
+  content = content.replace(/(^[var]+)\s([\w]+)([\;])/g, '$1 $2 = window["$2"]$3');
+
   var keys = Object.keys(modules);
   keys.forEach(function (mod) {
     var globalProp = "window[" + JSON.stringify(mod) + "]";


### PR DESCRIPTION
webpack create a closure for the moduleName and therefore the global moduleName will be 'new' in the module and will not use the other modules that are in the global moduleName. 

@felixmosh please merge